### PR TITLE
Suggestion to add a note to the DTO documentation

### DIFF
--- a/core/dto.md
+++ b/core/dto.md
@@ -82,6 +82,8 @@ final class BookInput {
 }
 ```
 
+> Note: When using serialization group annotations (@Groups("book") for example) the fields in the data transformers (for example BookInput::isbn) which are to be serialized should also have their serialization group annotation added.
+
 We can transform the `BookInput` to a `Book` resource instance:
 
 ```php


### PR DESCRIPTION
Currently it isn't quite clear that serialization group annotations should be added to the classes used for data transformation. At least not explicitly. The note on line 85 should solve that.

<!--

If your pull request fixes a BUG, use the last stable branch that contains the bug.

If your pull request documents a NEW FEATURE, use the `master` branch.

-->
